### PR TITLE
Fixing accessibility issue with tabbing on screens for mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,11 +69,12 @@
       id="mobile-menu"
       class="hidden w-full fixed z-50 mt-[75px] sm:hidden"
     >
-      <i
-        id="close-btn"
-        class="fa-solid fa-xmark text-mintGreen text-2xl absolute right-0 mt-4 mr-[32px] hover:text-icyWhite hover:cursor-pointer"
-        onclick="closeMobileMenu()"
-      ></i>
+      <button class="float-right" onclick="closeMobileMenu()">
+        <i
+          id="close-btn"
+          class="fa-solid fa-xmark text-mintGreen text-2xl mr-[32px] mt-4 hover:text-icyWhite hover:cursor-pointer"
+        ></i>
+      </button>
       <ul class="text-xl flex flex-col justify-around items-center gap-3 my-5">
         <li>
           <a

--- a/index.html
+++ b/index.html
@@ -56,11 +56,12 @@
           </li>
         </ul>
 
-        <i
-          id="menu-bars"
-          class="fa-solid fa-bars text-mintGreen text-2xl hover:text-icyWhite hover:cursor-pointer sm:hidden"
-          onclick="openMobileMenu()"
-        ></i>
+        <button onclick="openMobileMenu()">
+          <i
+            id="menu-bars"
+            class="fa-solid fa-bars text-mintGreen text-2xl hover:text-icyWhite hover:cursor-pointer sm:hidden"
+          ></i>
+        </button>
       </nav>
     </header>
 


### PR DESCRIPTION
This pull request addresses an issue where users were unable to access the full functionality of the site when tabbing through on browser screens for mobile devices. Specifically, users were unable to access the menu bars icon when the browser was resized, and they were unable to access the close button when the navigation menu was open.

To fix this issue, I wrapped both `<i>` elements that were imported from Font Awesome Icon inside a `<button>` element. This is the correct way to do it since they are semantically used as buttons. With this change, users will now be able to access the full site using the tab button on mobile devices.